### PR TITLE
Clarify the Authentication Endpoint comment

### DIFF
--- a/lagom-cloud-object-storage-example/account-impl/src/main/resources/cloud-object-storage.conf.template
+++ b/lagom-cloud-object-storage-example/account-impl/src/main/resources/cloud-object-storage.conf.template
@@ -12,7 +12,8 @@ cloud-object-storage {
   bucket = ""
 
 
-  # Must be filled with one of the Authentication Endpoint available
+  # Must be filled with one of the public Authentication Endpoints
+  # in the region or cross-region area where the bucket is located.
   # In COS details page > "Access & Permissions" > "Authentication Endpoints"
   host = ""
 


### PR DESCRIPTION
If you choose an endpoint that is not located in the same region/cross-region as the bucket, you get a big error when the service tries to archive.