### PR TITLE
Update Cloud Object Storage example to 1.4.0

### DIFF
--- a/lagom-cloud-object-storage-example/account-api/pom.xml
+++ b/lagom-cloud-object-storage-example/account-api/pom.xml
@@ -22,5 +22,9 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/lagom-cloud-object-storage-example/pom.xml
+++ b/lagom-cloud-object-storage-example/pom.xml
@@ -91,6 +91,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lagom.version>1.3.8</lagom.version>
+        <lagom.version>1.4.0</lagom.version>
     </properties>
 </project>


### PR DESCRIPTION
Had to explicitly add a dependency to SLF4J in the API project. I guess this was transitively added in previous versions.

I tried to bump the Alpakka version to 0.17 (from 0.12) but there's changes in the S3 API and since I couldn't setup a bucket in bluemix to test I kept the change to a minimum.

After this change all example `curl` commands in the `README` file work as expected.