### PR TITLE
Update Message Hub Liberty integration example to Lagom 1.4.1

### DIFF
--- a/lagom-message-hub-liberty-integration-example/message-hub-liberty-integration-api/pom.xml
+++ b/lagom-message-hub-liberty-integration-example/message-hub-liberty-integration-api/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-api_2.11</artifactId>
+            <artifactId>lagom-javadsl-api_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/lagom-message-hub-liberty-integration-example/message-hub-liberty-integration-impl/pom.xml
+++ b/lagom-message-hub-liberty-integration-example/message-hub-liberty-integration-impl/pom.xml
@@ -22,32 +22,32 @@
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-server_2.11</artifactId>
+            <artifactId>lagom-javadsl-server_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-kafka-broker_2.11</artifactId>
+            <artifactId>lagom-javadsl-kafka-broker_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-persistence-cassandra_2.11</artifactId>
+            <artifactId>lagom-javadsl-persistence-cassandra_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-pubsub_2.11</artifactId>
+            <artifactId>lagom-javadsl-pubsub_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-logback_2.11</artifactId>
+            <artifactId>lagom-logback_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.typesafe.play</groupId>
-            <artifactId>play-netty-server_2.11</artifactId>
+            <artifactId>play-netty-server_${scala.binary.version}</artifactId>
         </dependency>
         <!-- Service Locator Provider -->
         <dependency>
             <groupId>com.lightbend</groupId>
-            <artifactId>lagom13-java-service-locator-dns_2.11</artifactId>
+            <artifactId>lagom14-java-service-locator-dns_${scala.binary.version}</artifactId>
         </dependency>
 
         <dependency>
@@ -57,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-testkit_2.11</artifactId>
+            <artifactId>lagom-javadsl-testkit_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lagom-message-hub-liberty-integration-example/message-hub-liberty-integration-impl/src/main/resources/application.conf
+++ b/lagom-message-hub-liberty-integration-example/message-hub-liberty-integration-impl/src/main/resources/application.conf
@@ -18,11 +18,6 @@ message-hub-auth {
 akka.kafka.consumer.kafka-clients = ${message-hub-auth}
 akka.kafka.producer.kafka-clients = ${message-hub-auth}
 
-# Start consuming from the beginning of the topic on the first connection
-# Should be the default for Lagom consumers, but see https://github.com/lagom/lagom/issues/907
-akka.kafka.consumer.kafka-clients.auto.offset.reset = "earliest"
-
-
 # The default timeout of 3s seems too short to establish the connection to Message Hub
 akka.kafka.consumer.wakeup-timeout = 10s
 
@@ -34,3 +29,11 @@ lagom.persistence.read-side.cassandra.keyspace = message_hub_integration
 # Configure Akka Persistence Cassandra to read new events more quickly, for demo purposes
 cassandra-journal.pubsub-minimum-interval = 1s
 cassandra-query-journal.eventual-consistency-delay = 100ms
+
+# Enable new sharding state store mode by overriding Lagom's default
+akka.cluster.sharding.state-store-mode = ddata
+
+# Enable the serializer for akka.Done provided in Akka 2.5.8+ to avoid the use of Java serialization.
+akka.actor.serialization-bindings {
+  "akka.Done" = akka-misc
+}

--- a/lagom-message-hub-liberty-integration-example/pom.xml
+++ b/lagom-message-hub-liberty-integration-example/pom.xml
@@ -18,7 +18,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <groupId>com.lightbend.lagom</groupId>
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.20.1</version>
+                <version>0.24.0</version>
                 <configuration>
                     <skip>true</skip>
                     <images>
@@ -109,17 +109,11 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <!-- IBM Message Hub requires a Kafka 0.10.2+ client -->
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-clients</artifactId>
-                <version>0.10.2.1</version>
-            </dependency>
             <!-- Service Locator Provider -->
             <dependency>
                 <groupId>com.lightbend</groupId>
-                <artifactId>lagom13-java-service-locator-dns_2.11</artifactId>
-                <version>2.0.0</version>
+                <artifactId>lagom14-java-service-locator-dns_${scala.binary.version}</artifactId>
+                <version>2.3.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -127,6 +121,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lagom.version>1.3.7</lagom.version>
+        <lagom.version>1.4.1</lagom.version>
+        <scala.binary.version>2.12</scala.binary.version>
     </properties>
 </project>


### PR DESCRIPTION
Includes several other dependency updates as well:

- Lagom to 1.4.1
- Scala to 2.12
- Service Locator DNS to 2.3.0
- Remove override of Kafka client version (now 0.11.0.1 transitively)
- Update Maven plugins to latest releases