### PR TITLE
Update Message Hub console example to Lagom 1.4.1

### DIFF
--- a/lagom-message-hub-example/kafka-java-console-sample-producer-api/pom.xml
+++ b/lagom-message-hub-example/kafka-java-console-sample-producer-api/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-api_2.11</artifactId>
+            <artifactId>lagom-javadsl-api_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/lagom-message-hub-example/message-hub-consumer-api/pom.xml
+++ b/lagom-message-hub-example/message-hub-consumer-api/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-api_2.11</artifactId>
+            <artifactId>lagom-javadsl-api_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/lagom-message-hub-example/message-hub-consumer-impl/pom.xml
+++ b/lagom-message-hub-example/message-hub-consumer-impl/pom.xml
@@ -28,23 +28,23 @@
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-server_2.11</artifactId>
+            <artifactId>lagom-javadsl-server_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-kafka-client_2.11</artifactId>
+            <artifactId>lagom-javadsl-kafka-client_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-pubsub_2.11</artifactId>
+            <artifactId>lagom-javadsl-pubsub_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-logback_2.11</artifactId>
+            <artifactId>lagom-logback_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.typesafe.play</groupId>
-            <artifactId>play-netty-server_2.11</artifactId>
+            <artifactId>play-netty-server_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 

--- a/lagom-message-hub-example/message-hub-consumer-impl/src/main/resources/application.conf
+++ b/lagom-message-hub-example/message-hub-consumer-impl/src/main/resources/application.conf
@@ -13,10 +13,6 @@ akka.kafka.consumer.kafka-clients {
   ssl.protocol = TLSv1.2
   ssl.enabled.protocols = TLSv1.2
   ssl.endpoint.identification.algorithm = HTTPS
-
-  # Start consuming from the beginning of the topic on the first connection
-  # Should be the default for Lagom consumers, but see https://github.com/lagom/lagom/issues/907
-  auto.offset.reset = "earliest"
 }
 
 # The default timeout of 3s seems too short to establish the connection to Message Hub

--- a/lagom-message-hub-example/pom.xml
+++ b/lagom-message-hub-example/pom.xml
@@ -18,10 +18,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.6</version>
-            </plugin>
-            <plugin>
                 <groupId>com.lightbend.lagom</groupId>
                 <artifactId>lagom-maven-plugin</artifactId>
                 <version>${lagom.version}</version>
@@ -35,7 +31,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -77,18 +73,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <!-- IBM Message Hub requires a Kafka 0.10.2+ client -->
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-clients</artifactId>
-                <version>0.10.2.1</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lagom.version>1.3.7</lagom.version>
+        <lagom.version>1.4.1</lagom.version>
+        <scala.binary.version>2.12</scala.binary.version>
     </properties>
 </project>


### PR DESCRIPTION
- Use Scala 2.12
- Update Maven plugins to latest releases
- Remove override of Kafka client version (now 0.11.0.1 transitively)

Resolves #19