### PR TITLE
Update Db2 example to Lagom 1.4.1

### DIFF
--- a/lagom-jpa-db2-example/hello-api/pom.xml
+++ b/lagom-jpa-db2-example/hello-api/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-api_2.11</artifactId>
+            <artifactId>lagom-javadsl-api_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/lagom-jpa-db2-example/hello-impl/pom.xml
+++ b/lagom-jpa-db2-example/hello-impl/pom.xml
@@ -23,26 +23,17 @@
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-server_2.11</artifactId>
+            <artifactId>lagom-javadsl-server_${scala.binary.version}</artifactId>
         </dependency>
         <!-- lagom-javadsl-persistence-jpa enables RDBMS persistent entity and JPA read-side support. -->
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-persistence-jpa_2.11</artifactId>
+            <artifactId>lagom-javadsl-persistence-jpa_${scala.binary.version}</artifactId>
         </dependency>
         <!-- Lagom allows you to configure a JPA provider of your choice. Hibernate is recommended. -->
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-        </dependency>
-        <!--
-          - Lagom relies on Slick (http://slick.lightbend.com/) for its RDBMS support.
-          - Each service must configure Slick with the correct driver for the database in its application.conf file.
-          - Db2 support is provided by Slick Extensions (http://slick.lightbend.com/doc/3.1.1/extensions.html).
-          -->
-        <dependency>
-            <groupId>com.typesafe.slick</groupId>
-            <artifactId>slick-extensions_2.11</artifactId>
         </dependency>
         <!--
           - This is the Db2 JDBC driver, which is not available in a public Maven repository.
@@ -54,15 +45,15 @@
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-logback_2.11</artifactId>
+            <artifactId>lagom-logback_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.typesafe.play</groupId>
-            <artifactId>play-netty-server_2.11</artifactId>
+            <artifactId>play-netty-server_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.lightbend.lagom</groupId>
-            <artifactId>lagom-javadsl-testkit_2.11</artifactId>
+            <artifactId>lagom-javadsl-testkit_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lagom-jpa-db2-example/hello-impl/src/main/resources/application.conf
+++ b/lagom-jpa-db2-example/hello-impl/src/main/resources/application.conf
@@ -20,6 +20,13 @@ db.default {
 }
 
 # Lagom relies on Slick (http://slick.lightbend.com/) for its RDBMS support.
-# Each service must configure Slick with the correct driver for the database in its application.conf file.
-# Db2 support is provided by Slick Extensions (http://slick.lightbend.com/doc/3.1.1/extensions.html).
-jdbc-defaults.slick.driver = "com.typesafe.slick.driver.db2.DB2Driver$"
+# Each service must configure Slick with the correct profile for the database in its application.conf file.
+jdbc-defaults.slick.profile = "slick.jdbc.DB2Profile$"
+
+# Enable new sharding state store mode by overriding Lagom's default
+akka.cluster.sharding.state-store-mode = ddata
+
+# Enable the serializer for akka.Done provided in Akka 2.5.8+ to avoid the use of Java serialization.
+akka.actor.serialization-bindings {
+  "akka.Done" = akka-misc
+}

--- a/lagom-jpa-db2-example/pom.xml
+++ b/lagom-jpa-db2-example/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -79,17 +79,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>5.2.10.Final</version>
-            </dependency>
-            <!--
-              - Lagom relies on Slick (http://slick.lightbend.com/) for its RDBMS support.
-              - Each service must configure Slick with the correct driver for the database in its application.conf file.
-              - Db2 support is provided by Slick Extensions (http://slick.lightbend.com/doc/3.1.1/extensions.html).
-              -->
-            <dependency>
-                <groupId>com.typesafe.slick</groupId>
-                <artifactId>slick-extensions_2.11</artifactId>
-                <version>3.1.0</version>
+                <version>5.2.15.Final</version>
             </dependency>
             <!--
               - This is the Db2 JDBC driver, which is not available in a public Maven repository.
@@ -103,18 +93,10 @@
         </dependencies>
     </dependencyManagement>
 
-    <repositories>
-        <!-- This repository configuration is needed for Slick Extensions. -->
-        <repository>
-            <id>typesafe-releases</id>
-            <name>Typesafe Releases</name>
-            <url>https://repo.typesafe.com/typesafe/maven-releases/</url>
-        </repository>
-    </repositories>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lagom.version>1.3.8</lagom.version>
+        <lagom.version>1.4.1</lagom.version>
+        <scala.binary.version>2.12</scala.binary.version>
     </properties>
 </project>


### PR DESCRIPTION
- Update to latest stable Hibernate (5.2.15)
- Update Scala to 2.12
- Update Slick profile configuration
- Remove Slick Extensions dependency (now part of core Slick)
- Update Maven Compiler Plugin to 3.7.0
- Add recommended default configuration to application.conf

Resolves #18